### PR TITLE
Add cmake install directives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(libevdevPlus)
 set(SOURCE_FILES
         evdevPlus.cpp evdevPlus.hpp CommonIncludes.hpp InputEvent.hpp Resource.cpp)
 
+include(GNUInstallDirs)
+
 add_library(evdevPlus ${SOURCE_FILES})
 target_include_directories(evdevPlus PUBLIC .)
 
@@ -11,3 +13,8 @@ add_executable(evdevPlus_test test.cpp)
 target_link_libraries(evdevPlus_test evdevPlus)
 
 configure_file(evdevPlus.pc.in evdevPlus.pc @ONLY)
+
+install(TARGETS evdevPlus
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES evdevPlus.hpp CommonIncludes.hpp InputEvent.hpp
+        DESTINATION include/)


### PR DESCRIPTION
To make nix builds work, it expect a make install command to
be available.
Adding these directives seems to fix the build.

If it's no trouble to you, please add them.