### PR TITLE
Fix: EventDevice: Actually save file descriptor after opening file from path

### DIFF
--- a/evdevPlus.cpp
+++ b/evdevPlus.cpp
@@ -22,7 +22,7 @@ void EventDevice::__open(const std::string &path, int open_flags) {
 		throw std::system_error(errno, std::system_category(), "failed to open device");
 
 	path_ = path;
-
+  fd_ = fd;
 }
 
 void EventDevice::__close() {


### PR DESCRIPTION


EventDevice has a constructor that opens from a path; however, it does
not actually save the file descriptor for the open file causing
initialization to always fail. This fixes that.

I found this bug when trying to use the record feature of [ydotool](https://github.com/ReimuNotMoe/ydotool) which appears to be a related project.